### PR TITLE
Implement function save_nominal_telescope_pointings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
@@ -26,4 +27,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
+HDF5 = "0.17.2"
 julia = "1.3"

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -77,11 +77,13 @@ import StaticArrays
 import LinearAlgebra: ×, dot
 import AstroLib
 import Dates
+import HDF5
 
 export TENERIFE_LATITUDE_DEG, TENERIFE_LONGITUDE_DEG, TENERIFE_HEIGHT_M
 export configuration_angles, ConfigAngles
 export timetorotang, telescopetoground, groundtoearth
 export genpointings!, genpointings, northdir, eastdir, polarizationangle
+export save_nominal_telescope_pointings
 
 "Latitude of the LSPE/Strip site in Tenerife, in degrees"
 const TENERIFE_LATITUDE_DEG = 28.30026
@@ -116,11 +118,11 @@ abstract type ConfigAngles end
         zVAXang_rad :: Float64 = 0,
         panang_rad :: Float64 = 0,
         tiltang_rad :: Float64 = 0,
-        rollang_rad :: Float64 = 0,   
+        rollang_rad :: Float64 = 0,
     )
 
 Struct containing the configuration angles for the telescope i.e. the angles describing
-the non idealities in the telescope (all of these parameters are considered equal to 0 in 
+the non idealities in the telescope (all of these parameters are considered equal to 0 in
 an ideal telescope):
 
 (`wheel1ang_0_rad`, `wheel2ang_0_rad`, `wheel3ang_0_rad`): these are the zero points angles for the three motors
@@ -219,7 +221,7 @@ end
 
 Return a quaternion of type `Quaternion{Float64}` representing the
 coordinate transform from the focal plane to the ground of the
-telescope. 
+telescope.
 The parameter `config_ang` must be a configuration_angles struct
 containing the angles describing the non idealities of the telescope.
 
@@ -679,9 +681,9 @@ The meaning of the parameters/keywords is the following:
   As these corrections are only valid for optical wavelengths, the
   default is `false`.
 
-- `config_ang`: specifies the configuration angles for the camera and for the 
+- `config_ang`: specifies the configuration angles for the camera and for the
   telescope (see [`configuration_angles`](@ref) for more details). This is used
-  internally by [`telescopetoground`](@ref); if nothing is passes then the version 
+  internally by [`telescopetoground`](@ref); if nothing is passes then the version
   of telescopetoground for an ideal telescope will be used.
 
 # Return values
@@ -728,3 +730,110 @@ dirs, psi = genpointings(time_s -> (0, deg2rad(20),
 `````
 """
 genpointings
+
+@doc raw"""
+    save_nominal_telescope_pointings(
+        file::HDF5.File,
+        t_start::Dates.DateTime,
+        timerange_s;
+        altitude_deg = 20.0,
+        ground_rotation_rpm = 1.0,
+        latitude_deg = TENERIFE_LATITUDE_DEG,
+        longitude_deg = TENERIFE_LONGITUDE_DEG,
+        height_m = TENERIFE_HEIGHT_M,
+    )
+
+Simulate the reading of the two telescope encoders and save them
+in the HDF5 file `file`. The parameters have the same meaning as
+in the [`genpointings`](@ref) function.
+
+# Example
+
+`````julia
+import Dates
+import HDF5
+
+h5open("test.h5", "w") do file
+    save_nominal_telescope_pointings(
+        file,
+        Dates.DateTime(2025, 1, 1, 0, 0, 0),
+        0.0:0.1:1.0,
+    )
+end
+`````
+"""
+function save_nominal_telescope_pointings(
+    file::HDF5.File,
+    t_start::Dates.DateTime,
+    timerange_s;
+    altitude_deg = 20.0,
+    ground_rotation_rpm = 1.0,
+    latitude_deg = TENERIFE_LATITUDE_DEG,
+    )
+
+    dirs, _ = genpointings(
+        [0., 0., 1.],
+        timerange_s,
+        latitude_deg = latitude_deg,
+        ground = true,
+    ) do time_s
+        (0.0, deg2rad(altitude_deg), timetorotang(time_s, ground_rotation_rpm))
+    end
+    @assert size(dirs, 2) == 4
+
+    nsamples = length(timerange_s)
+
+
+    # Add file-level metadata
+    for (key, value) in Dict(
+        "Description" => "Telescope raw pointing file",
+        "Creator" => "Stripeline.jl",
+        "Created" => Dates.format(Dates.now(), "yyyy-mm-dd HH:MM:SS"),
+        "CreatorVersion" => "1.0",
+        "FileVersion" => "V0",
+        "Source" => "LevelS",
+        "Prescaler" => Int32(0),
+        "SamplingPeriod" => Float64(-1.0),
+        "Nsamp" => nsamples,
+        "MaximumHDFSize" => Int32(-1),
+    )
+        HDF5.attributes(file)[key] = value
+    end
+
+    timestamp_MC = Array{Int64}(undef, nsamples)
+    ticks_since_TOS = Int32(1):Int32(nsamples) |> collect
+    mjd = Array{Float64}(undef, nsamples)
+
+    for (i, time_s) in enumerate(timerange_s)
+        cur_time = t_start + Dates.Nanosecond(round(Int64, time_s * 1e9))
+        timestamp_MC[i] = Int64(floor(Dates.datetime2unix(cur_time)))
+        mjd[i] = AstroLib.jdcnv(cur_time)
+    end
+
+    # Create groups and save data in each group with group-level metadata
+    henc_group = HDF5.create_group(file, "H-ENC")
+    venc_group = HDF5.create_group(file, "V-ENC")
+
+    HDF5.attributes(henc_group)["Description"] = "Reading of the encoder for the H-AXIS"
+    HDF5.attributes(henc_group)["Encoder"] = "H-AXIS"
+
+    HDF5.attributes(venc_group)["Description"] = "Reading of the encoder for the V-AXIS"
+    HDF5.attributes(venc_group)["Encoder"] = "V-AXIS"
+
+    henc_group["encoder_pos"] = dirs[:, 3]
+    venc_group["encoder_pos"] = dirs[:, 4]
+
+    # Add dataset-level data and metadata that are common to the two groups
+    for cur_group in (henc_group, venc_group)
+        cur_group["timestamp_MC"] = timestamp_MC
+        cur_group["ticks_since_TOS"] = ticks_since_TOS
+        cur_group["status"] = fill(UInt32(0xffffffff), nsamples)
+        cur_group["fault"] = fill(UInt32(0x0), nsamples)
+        cur_group["mjd"] = mjd
+
+        HDF5.attributes(cur_group["encoder_pos"])["units"] = "adu"
+        HDF5.attributes(cur_group["timestamp_MC"])["units"] = "s"
+        HDF5.attributes(cur_group["ticks_since_TOS"])["units"] = "ticks"
+        HDF5.attributes(cur_group["mjd"])["units"] = "MJD"
+    end
+end

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -769,10 +769,10 @@ function save_nominal_telescope_pointings(
     altitude_deg = 20.0,
     ground_rotation_rpm = 1.0,
     latitude_deg = TENERIFE_LATITUDE_DEG,
-    )
+)
 
     dirs, _ = genpointings(
-        [0., 0., 1.],
+        [0.0, 0.0, 1.0],
         timerange_s,
         latitude_deg = latitude_deg,
         ground = true,

--- a/test/scanning.jl
+++ b/test/scanning.jl
@@ -4,6 +4,7 @@ using Dates
 using AstroLib
 using Healpix
 using StaticArrays
+using HDF5
 #const Sl = Stripeline
 
 # These are the old values that were used by @fincardona to test
@@ -430,4 +431,30 @@ let times = 0.0:0.1:1.0, latitude_deg = 28.29
     @test psi_solar[9] ≈ 1.4640145820540134
     @test psi_solar[10] ≈ 1.4501962359892084
     @test psi_solar[11] ≈ 1.4363879784382272
+end
+
+# Test that HDF5 files can be saved
+let time_range_s = 0.0:0.1:1.0, test_file = tempname()
+    h5open(test_file, "w") do file
+        save_nominal_telescope_pointings(
+            file,
+            Dates.DateTime(2025, 1, 1, 0, 0, 0),
+            time_range_s,
+        )
+    end
+
+    h5open(test_file, "r") do file
+        @test "H-ENC" in keys(file)
+        @test "V-ENC" in keys(file)
+
+        for cur_group_name in ("H-ENC", "V-ENC")
+            cur_group = file[cur_group_name]
+            @test length(cur_group["encoder_pos"]) == length(time_range_s)
+            @test length(cur_group["fault"]) == length(time_range_s)
+            @test length(cur_group["mjd"]) == length(time_range_s)
+            @test length(cur_group["status"]) == length(time_range_s)
+            @test length(cur_group["ticks_since_TOS"]) == length(time_range_s)
+            @test length(cur_group["timestamp_MC"]) == length(time_range_s)
+        end
+    end
 end


### PR DESCRIPTION
This PR is a WIP. The purpose is to create a function that saves encoders’ readings in HDF5 files that are conformant with Specification Document LSPE-SP-032 (*Telescope raw pointing file format*).

Here is an example that shows how to use the function:

```julia
h5open("file.h5", "w") do file
    save_nominal_telescope_pointings(
        file,
        Dates.DateTime(2025, 1, 1, 0, 0, 0),
        0.0:2.0:3600.0,  # One hour of data
    )
end
```
